### PR TITLE
Update package.json and package-lock.json to use tiny-async-pool from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-dynamodb-fixtures",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5322,10 +5322,12 @@
       "dev": true
     },
     "tiny-async-pool": {
-      "version": "github:rxaviers/async-pool#8cbdb5bf1227ef654673fcb822d30ad79adbccfb",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.0.1.tgz",
+      "integrity": "sha512-nqqQJ3ZwO/ajCk9hJisYWiW1pKgGZqxQPk2Q/2rzL84GyaFZ3N75sYcvpM+T6OYndgM4UqnezmGURHzQq7D64w==",
       "requires": {
         "assertion": "github:rxaviers/assertion#ea0449073d2c9e276c447f03df0fa021228de11b",
-        "semver": "5.5.0"
+        "semver": "^5.5.0"
       }
     },
     "tmp": {
@@ -5334,7 +5336,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     },
     "dependencies": {
         "aws-sdk": "^2.267.1",
-        "tiny-async-pool": "github:rxaviers/async-pool",
+        "tiny-async-pool": "^1.0.1",
         "uuid": "^3.3.2"
     }
 }


### PR DESCRIPTION
See title

The use of a `github` module requires `git` to be installed, which doesn't work well on CIs and production systems. I didn't see a specific reason for it, so I swapped it out to use `tiny-async-pool` which is available on npm.

<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes nothing

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

```bash
npm uninstall --save tiny-async-pool
npm install --save tiny-async-pool
git diff
git add --all # not really
git commit
git push
```

more or less…

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

```
npm install
npm test
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
